### PR TITLE
feat: Allow hyphens "-" in process names to be compatible with Heroku and Ruby's Foreman tool.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub fn parse<'a>(content: &'a str) -> Result<DashMap<&'a str, Process>> {
     lazy_static! {
         static ref REGEX: Regex =
-            Regex::new(r"^([A-Za-z0-9_]+):\s*(.+)$").expect("Failed building regex");
+            Regex::new(r"^([A-Za-z0-9_-]+):\s*(.+)$").expect("Failed building regex");
     }
 
     let map: DashMap<&'a str, Process> = DashMap::new();


### PR DESCRIPTION
Presently the regex for capturing process names does not allow a hyphen "-".

While the [comment](https://github.com/ddollar/foreman/blob/a5f9b78fa5cf657733c8a4cfd01b2c0c151b4fce/lib/foreman/procfile.rb#L7) at the top of procfile.rb indicates that hyphens are not allowed, the [actual regex used](https://github.com/ddollar/foreman/blob/a5f9b78fa5cf657733c8a4cfd01b2c0c151b4fce/lib/foreman/procfile.rb#L88) does allow hyphens.

See also:

https://github.com/ddollar/foreman/pull/791